### PR TITLE
rename min and max length to mustHave

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "parser": "typescript"
+}

--- a/src/GenericFormInputPresenter.ts
+++ b/src/GenericFormInputPresenter.ts
@@ -92,11 +92,11 @@ export class GenericFormInputPresenter<T> {
     return this.addCustomRule(MUST_BE_NUMBER, errorMessage)
   }
 
-  public minLength = (length: number, errorMessage?: string) => {
+  public mustHaveMinLength = (length: number, errorMessage?: string) => {
     return this.addCustomRule(MIN_LENGTH(length), errorMessage)
   }
 
-  public maxLength = (length: number, errorMessage?: string) => {
+  public mustHaveMaxLength = (length: number, errorMessage?: string) => {
     return this.addCustomRule(MAX_LENGTH(length), errorMessage)
   }
 


### PR DESCRIPTION
minLength and maxLength are part of html and should be strings or numbers. Using mustHaveMinLength and mustHaveMaxLength also brings the functions more inline with mustBeString() and similar rule functions.